### PR TITLE
Add flexibility into the allowable network ranges that can access the loadbalancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Checkout [examples](./examples) for fully functioning examples.
 - `ssh_key_name`: [Required] Name of AWS keypair that will be created.
 - `use_lb_cert`: [Optional] Use certificate passed in for the LB IAM listener, "lb_cert" and "lb_private_key" must be passed in if true, defaults to false.
 - `lb_cert`: [Optional] Certificate for LB IAM server certificate.
+- `lb_inbound_cidrs`: [Optional] List of CIDRs to accept inbound connections into the loadbalancer 
 - `lb_private_key`: [Optional] Private key for LB IAM server certificate.
 - `lb_cert_chain`: [Optional] Certificate chain for LB IAM server certificate.
 - `lb_ssl_policy`: [Optional] SSL policy for LB, defaults to "ELBSecurityPolicy-2016-08".

--- a/main.tf
+++ b/main.tf
@@ -84,7 +84,8 @@ module "consul_lb_aws" {
   create             = "${var.create}"
   name               = "${var.name}"
   vpc_id             = "${var.vpc_id}"
-  cidr_blocks        = ["${var.public ? "0.0.0.0/0" : var.vpc_cidr}"] # If there's a public IP, open port 22 for public access - DO NOT DO THIS IN PROD
+  cidr_blocks        = ["${split(",", var.public ? join(",", list("0.0.0.0/0") ) : join(",", concat(list(var.vpc_cidr), var.lb_inbound_cidrs ) ) )}"] # If there's a public IP, open port 22 for public access - DO NOT DO THIS IN PROD
+
   subnet_ids         = ["${var.subnet_ids}"]
   is_internal_lb     = "${!var.public}"
   use_lb_cert        = "${var.use_lb_cert}"

--- a/variables.tf
+++ b/variables.tf
@@ -105,6 +105,12 @@ variable "lb_ssl_policy" {
   default     = "ELBSecurityPolicy-2016-08"
 }
 
+variable "lb_inbound_cidrs" {
+  description = "The inbound CIDRS to allow traffic to the load balancer"
+  type = "list"
+  default = []
+}
+
 variable "lb_bucket" {
   description = "S3 bucket override for LB access logs, `lb_bucket_override` be set to true if overriding"
   default     = ""


### PR DESCRIPTION
I ran into a limitation with using a non-public LB setup with consul and also vault which I can also submit a PR for if we are OK with this change for consul.  We have our network extended into AWS and want to limit the CIDR ranges that exist on that internal network that have access to the loadbalancer.  This gives us an optional list we can pass into the module to add that access to that range.  

I ran this against my own TF I have for provisioning a consul cluster and it updates the SG rules as I would expect. 